### PR TITLE
Added a character limit to the name field for adding locations.

### DIFF
--- a/app/src/main/res/layout/activity_add.xml
+++ b/app/src/main/res/layout/activity_add.xml
@@ -21,6 +21,7 @@
             android:hint="@string/location_name_hint"
             android:inputType="textPersonName"
             android:paddingLeft="2dp"
+            android:maxLength="20"
             android:paddingRight="2dp" />
 
         <TextView


### PR DESCRIPTION
Users can now only enter up to 20 characters.
This is to prevent users from entering extremely long names that
affect the performance of the app.