### PR TITLE
Fix for deleted locations remaining in memory.

### DIFF
--- a/app/src/main/java/com/hushproject/hush/LocationViewAdapter.java
+++ b/app/src/main/java/com/hushproject/hush/LocationViewAdapter.java
@@ -113,6 +113,10 @@ public class LocationViewAdapter extends RecyclerView.Adapter<LocationViewAdapte
                     //use cardKey to remove the sharedpreferences from prefs file.
                     editor.remove(cardKey);
                     editor.commit();
+
+                    Intent restartService = new Intent(context, ForegroundService.class);
+                    context.stopService(restartService);
+                    context.startService(restartService);
                 }
             });
         }


### PR DESCRIPTION
ForegroundService is now stopped and restarted whenever you delete a
profile.